### PR TITLE
Fix NullPointerException when no nodes are found

### DIFF
--- a/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/GoToCommand.java
+++ b/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/GoToCommand.java
@@ -91,6 +91,15 @@ public class GoToCommand implements CommandExecutor {
             Node playerNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToPlayer)));
             Node locationNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToLocation)));
 
+            if (playerNode == null) {
+                p.sendMessage(ChatColor.RED + "No node found near player");
+                return true;
+            }
+            if (locationNode == null) {
+                p.sendMessage(ChatColor.RED + "No node found near destination");
+                return true;
+            }
+
             p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
             Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
                 // start timer

--- a/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/GoToCommand.java
+++ b/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/GoToCommand.java
@@ -91,12 +91,8 @@ public class GoToCommand implements CommandExecutor {
             Node playerNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToPlayer)));
             Node locationNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToLocation)));
 
-            if (playerNode == null) {
-                p.sendMessage(ChatColor.RED + "No node found near player");
-                return true;
-            }
-            if (locationNode == null) {
-                p.sendMessage(ChatColor.RED + "No node found near destination");
+            if (playerNode == null || locationNode == null) {
+                p.sendMessage(ChatColor.RED + "No node founds. Try creating a road first.");
                 return true;
             }
 

--- a/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
+++ b/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
@@ -110,7 +110,7 @@ public class NavigationCommand implements CommandExecutor {
             return;
         }
 
-		p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
+        p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 
             // starting timer

--- a/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
+++ b/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
@@ -105,6 +105,15 @@ public class NavigationCommand implements CommandExecutor {
         Node playerNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToPlayer)));
         Node locationNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToLocation)));
 
+        if (playerNode == null) {
+            p.sendMessage(ChatColor.RED + "No node found near player");
+            return;
+        }
+        if (locationNode == null) {
+            p.sendMessage(ChatColor.RED + "No node found near destination");
+            return;
+        }
+
         p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 

--- a/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
+++ b/src/main/java/nl/abelkrijgtalles/MojangMaps/command/using/NavigationCommand.java
@@ -105,16 +105,12 @@ public class NavigationCommand implements CommandExecutor {
         Node playerNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToPlayer)));
         Node locationNode = findNodeByName(nodes, String.valueOf(NodesConfigUtil.getLocations().indexOf(closestLocationToLocation)));
 
-        if (playerNode == null) {
-            p.sendMessage(ChatColor.RED + "No node found near player");
-            return;
-        }
-        if (locationNode == null) {
-            p.sendMessage(ChatColor.RED + "No node found near destination");
+        if (playerNode == null || locationNode == null) {
+            p.sendMessage(ChatColor.RED + "No node founds. Try creating a road first.");
             return;
         }
 
-        p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
+		p.sendMessage(ChatColor.YELLOW + MessageUtil.getMessage("load"));
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
 
             // starting timer


### PR DESCRIPTION
When no nodes are found (for example: no roads have been created) when running `/goto 1 1 1` or `/navigation 1 1 1` the following error occurs
```
[13:10:43] [Craft Scheduler Thread - 12/WARN] [MojangMaps/]: Plugin MojangMaps v1.5.2 generated an exception while executing task 54
java.lang.NullPointerException: Cannot invoke "nl.abelkrijgtalles.MojangMaps.object.Node.setDistance(java.lang.Integer)" because "source" is null
        at nl.abelkrijgtalles.MojangMaps.object.Node.calculateShortestPath(Node.java:79) ~[?:?] {}
        at nl.abelkrijgtalles.MojangMaps.command.using.NavigationCommand.lambda$openGUI$1(NavigationCommand.java:122) ~[?:?] {}
        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftTask.run(CraftTask.java:82) ~[arclight-1.20.1-1.0.2-SNAPSHOT-f347f85.jar%23131!/:arclight-1.20.1-1.0.2-SNAPSHOT-f347f85] {re:classloading}
        at org.bukkit.craftbukkit.v1_20_R1.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54) ~[arclight-1.20.1-1.0.2-SNAPSHOT-f347f85.jar%23131!/:arclight-1.20.1-1.0.2-SNAPSHOT-f347f85] {re:classloading}
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?] {re:mixin}
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?] {}
        at java.lang.Thread.run(Thread.java:833) ~[?:?] {re:mixin,re:mixin,re:mixin}
```

When no nodes exist, the commands will produce "No node found near player" or "No node found near destination". I that that no one will see the "No node found near destination" message when nodes do exist because there will always be one, however it is still better to do the check.

You should probably add my extra messages into the language files.